### PR TITLE
feat: multi region replica strike implementation

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,9 +25,9 @@ var (
 		"CCC-Taxonomy": {
 			Strikes.SQLFeatures,
 			Strikes.AutomatedBackups,
+			Strikes.MultiRegion,
 			// Strikes.VerticalScaling,
 			// Strikes.Replication,
-			// Strikes.MultiRegion,
 			// Strikes.BackupRecovery,
 			// Strikes.Encryption,
 			// Strikes.RBAC,

--- a/example-config.yml
+++ b/example-config.yml
@@ -11,6 +11,7 @@ raids:
       config:
         instance_identifier: unique-id-name
         database: test
+        region: us-east-1
         host: localhost
         password: password
         port: 3306

--- a/example-config.yml
+++ b/example-config.yml
@@ -11,7 +11,7 @@ raids:
       config:
         instance_identifier: unique-id-name
         database: test
-        region: us-east-1
+        primary_region: us-east-1
         host: localhost
         password: password
         port: 3306

--- a/strikes/AutomatedBackups.go
+++ b/strikes/AutomatedBackups.go
@@ -23,7 +23,7 @@ func (a *Strikes) AutomatedBackups() (strikeName string, result raidengine.Strik
 		Movements:   make(map[string]raidengine.MovementResult),
 	}
 
-	// Movement
+	// Get Configuration
 	cfg, err := getAWSConfig()
 	if err != nil {
 		result.Message = err.Error()
@@ -37,40 +37,15 @@ func (a *Strikes) AutomatedBackups() (strikeName string, result raidengine.Strik
 		return
 	}
 
-	autmatedBackupsMovement := checkRDSAutomatedBackupMovement(cfg)
-	result.Movements["CheckForDBInstanceAutomatedBackups"] = autmatedBackupsMovement
-	if !autmatedBackupsMovement.Passed {
-		result.Message = autmatedBackupsMovement.Message
+	automatedBackupsMovement := checkRDSAutomatedBackupMovement(cfg)
+	result.Movements["CheckForDBInstanceAutomatedBackups"] = automatedBackupsMovement
+	if !automatedBackupsMovement.Passed {
+		result.Message = automatedBackupsMovement.Message
 		return
 	}
 
 	result.Passed = true
 	result.Message = "Completed Successfully"
-	return
-}
-
-func checkRDSInstanceMovement(cfg aws.Config) (result raidengine.MovementResult) {
-	// check if the instance is available
-	result = raidengine.MovementResult{
-		Description: "Check if the instance is available/exists",
-		Function:    utils.CallerPath(0),
-	}
-
-	rdsClient := rds.NewFromConfig(cfg)
-	identifier, _ := getDBInstanceIdentifier()
-
-	input := &rds.DescribeDBInstancesInput{
-		DBInstanceIdentifier: aws.String(identifier),
-	}
-
-	instances, err := rdsClient.DescribeDBInstances(context.TODO(), input)
-	if err != nil {
-		// Handle error
-		result.Message = err.Error()
-		result.Passed = false
-		return
-	}
-	result.Passed = len(instances.DBInstances) > 0
 	return
 }
 

--- a/strikes/AutomatedBackups.go
+++ b/strikes/AutomatedBackups.go
@@ -57,10 +57,10 @@ func checkRDSAutomatedBackupMovement(cfg aws.Config) (result raidengine.Movement
 	}
 
 	rdsClient := rds.NewFromConfig(cfg)
-	identifier, _ := getDBInstanceIdentifier()
+	instanceIdentifier, _ := getHostDBInstanceIdentifier()
 
 	input := &rds.DescribeDBInstanceAutomatedBackupsInput{
-		DBInstanceIdentifier: aws.String(identifier),
+		DBInstanceIdentifier: aws.String(instanceIdentifier),
 	}
 
 	backups, err := rdsClient.DescribeDBInstanceAutomatedBackups(context.TODO(), input)

--- a/strikes/MultiRegion.go
+++ b/strikes/MultiRegion.go
@@ -1,0 +1,96 @@
+package strikes
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/rds"
+	"github.com/privateerproj/privateer-sdk/raidengine"
+	"github.com/privateerproj/privateer-sdk/utils"
+)
+
+func (a *Strikes) MultiRegion() (strikeName string, result raidengine.StrikeResult) {
+	strikeName = "MultiRegion"
+	result = raidengine.StrikeResult{
+		Passed:      false,
+		Description: "Check if AWS RDS instance has multi region. This strike only checks for a read replica in a seperate region",
+		DocsURL:     "https://www.github.com/krumIO/raid-rds",
+		ControlID:   "CCC-Taxonomy-1",
+		Movements:   make(map[string]raidengine.MovementResult),
+	}
+
+	// Get Configuration
+	cfg, err := getAWSConfig()
+	if err != nil {
+		result.Message = err.Error()
+		return
+	}
+
+	rdsInstanceMovement := checkRDSInstanceMovement(cfg)
+	result.Movements["CheckForDBInstance"] = rdsInstanceMovement
+	if !rdsInstanceMovement.Passed {
+		result.Message = rdsInstanceMovement.Message
+		return
+	}
+
+	multiRegionMovement := checkRDSMultiRegionMovement(cfg)
+	result.Movements["CheckForMultiRegionDBInstances"] = multiRegionMovement
+	if !multiRegionMovement.Passed {
+		result.Message = multiRegionMovement.Message
+		return
+	}
+
+	result.Passed = true
+	result.Message = "Completed Successfully"
+
+	return
+}
+
+func checkRDSMultiRegionMovement(cfg aws.Config) (result raidengine.MovementResult) {
+
+	result = raidengine.MovementResult{
+		Description: "Check if the instance has multi region enabled",
+		Function:    utils.CallerPath(0),
+	}
+
+	rdsClient := rds.NewFromConfig(cfg)
+	identifier, _ := getDBInstanceIdentifier()
+
+	input := &rds.DescribeDBInstanceAutomatedBackupsInput{
+		DBInstanceIdentifier: aws.String(identifier),
+	}
+
+	backups, err := rdsClient.DescribeDBInstanceAutomatedBackups(context.TODO(), input)
+	if err != nil {
+		result.Message = "Failed to fetch automated backups for instance " + identifier
+		result.Passed = false
+		return
+	}
+
+	var regions []string
+	for _, backup := range backups.DBInstanceAutomatedBackups {
+		regions = append(regions, *backup.Region)
+	}
+
+	// This checks if theres a read replica in a different region
+	if len(regions) > 0 {
+		hostDBRegion := getRDSRegion()
+		for _, region := range regions {
+			// region from the instances are in the form of "use2"
+			abbreviation, exists := AWS_REGIONS_ABBR[hostDBRegion]
+			if exists {
+				if region != abbreviation {
+					result.Passed = true
+					result.Message = "Completed Successfully"
+					return
+				}
+			}
+
+		}
+	}
+
+	result.Passed = false
+	result.Message = "Multi Region instances not found"
+	return
+
+}

--- a/strikes/MultiRegion_test.go
+++ b/strikes/MultiRegion_test.go
@@ -1,0 +1,32 @@
+package strikes
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+func TestMultiRegion(t *testing.T) {
+	viper.AddConfigPath("../")
+	viper.SetConfigName("config")
+	viper.SetConfigType("yaml")
+	err := viper.ReadInConfig()
+
+	if err != nil {
+		fmt.Println("Config file not found...")
+		return
+	}
+
+	strikes := Strikes{}
+	strikeName, result := strikes.MultiRegion()
+
+	fmt.Println(strikeName)
+	b, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		fmt.Println(err)
+	}
+	fmt.Print(string(b))
+	fmt.Println()
+}

--- a/strikes/common.go
+++ b/strikes/common.go
@@ -14,26 +14,6 @@ import (
 	"github.com/spf13/viper"
 )
 
-var (
-	AWS_REGIONS_ABBR = map[string]string{
-		"us-east-1":      "use1",
-		"us-east-2":      "use2",
-		"us-west-1":      "usw1",
-		"us-west-2":      "usw2",
-		"ca-central-1":   "cac1",
-		"eu-west-1":      "euw1",
-		"eu-west-2":      "euw2",
-		"eu-central-1":   "euc1",
-		"eu-north-1":     "eun1",
-		"ap-northeast-1": "apne1",
-		"ap-northeast-2": "apne2",
-		"ap-southeast-1": "apse1",
-		"ap-southeast-2": "apse2",
-		"ap-south-1":     "aps1",
-		"sa-east-1":      "sae1",
-	}
-)
-
 type Strikes struct {
 	Log hclog.Logger
 }
@@ -53,15 +33,18 @@ func getDBConfig() (string, error) {
 	return "", errors.New("database url must be set in the config file")
 }
 
-func getDBInstanceIdentifier() (string, error) {
+func getHostDBInstanceIdentifier() (string, error) {
 	if viper.IsSet("raids.RDS.aws.config.instance_identifier") {
 		return viper.GetString("raids.RDS.aws.config.instance_identifier"), nil
 	}
 	return "", errors.New("database instance identifier must be set in the config file")
 }
 
-func getRDSRegion() string {
-	return viper.GetString("raids.RDS.aws.config.region")
+func getHostRDSRegion() (string, error) {
+	if viper.IsSet("raids.RDS.aws.config.region") {
+		return viper.GetString("raids.RDS.aws.config.region"), nil
+	}
+	return "", errors.New("database instance identifier must be set in the config file")
 }
 
 func getAWSConfig() (cfg aws.Config, err error) {
@@ -102,7 +85,9 @@ func checkRDSInstanceMovement(cfg aws.Config) (result raidengine.MovementResult)
 		Function:    utils.CallerPath(0),
 	}
 
-	instance, err := getRDSInstance(cfg)
+	instanceIdentifier, _ := getHostDBInstanceIdentifier()
+
+	instance, err := getRDSInstanceFromIdentifier(cfg, instanceIdentifier)
 	if err != nil {
 		// Handle error
 		result.Message = err.Error()
@@ -113,9 +98,8 @@ func checkRDSInstanceMovement(cfg aws.Config) (result raidengine.MovementResult)
 	return
 }
 
-func getRDSInstance(cfg aws.Config) (instance *rds.DescribeDBInstancesOutput, err error) {
+func getRDSInstanceFromIdentifier(cfg aws.Config, identifier string) (instance *rds.DescribeDBInstancesOutput, err error) {
 	rdsClient := rds.NewFromConfig(cfg)
-	identifier, _ := getDBInstanceIdentifier()
 
 	input := &rds.DescribeDBInstancesInput{
 		DBInstanceIdentifier: aws.String(identifier),

--- a/strikes/common.go
+++ b/strikes/common.go
@@ -7,10 +7,31 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/rds"
 	hclog "github.com/hashicorp/go-hclog"
 	"github.com/privateerproj/privateer-sdk/raidengine"
 	"github.com/privateerproj/privateer-sdk/utils"
 	"github.com/spf13/viper"
+)
+
+var (
+	AWS_REGIONS_ABBR = map[string]string{
+		"us-east-1":      "use1",
+		"us-east-2":      "use2",
+		"us-west-1":      "usw1",
+		"us-west-2":      "usw2",
+		"ca-central-1":   "cac1",
+		"eu-west-1":      "euw1",
+		"eu-west-2":      "euw2",
+		"eu-central-1":   "euc1",
+		"eu-north-1":     "eun1",
+		"ap-northeast-1": "apne1",
+		"ap-northeast-2": "apne2",
+		"ap-southeast-1": "apse1",
+		"ap-southeast-2": "apse2",
+		"ap-south-1":     "aps1",
+		"sa-east-1":      "sae1",
+	}
 )
 
 type Strikes struct {
@@ -39,10 +60,15 @@ func getDBInstanceIdentifier() (string, error) {
 	return "", errors.New("database instance identifier must be set in the config file")
 }
 
+func getRDSRegion() string {
+	return viper.GetString("raids.RDS.aws.config.region")
+}
+
 func getAWSConfig() (cfg aws.Config, err error) {
 	if viper.IsSet("raids.RDS.aws.creds") &&
 		viper.IsSet("raids.RDS.aws.creds.aws_access_key") &&
-		viper.IsSet("raids.RDS.aws.creds.aws_secret_key") {
+		viper.IsSet("raids.RDS.aws.creds.aws_secret_key") &&
+		viper.IsSet("raids.RDS.aws.creds.aws_region") {
 
 		access_key := viper.GetString("raids.RDS.aws.creds.aws_access_key")
 		secret_key := viper.GetString("raids.RDS.aws.creds.aws_secret_key")
@@ -66,5 +92,35 @@ func connectToDb() (result raidengine.MovementResult) {
 		return
 	}
 	result.Passed = true
+	return
+}
+
+func checkRDSInstanceMovement(cfg aws.Config) (result raidengine.MovementResult) {
+	// check if the instance is available
+	result = raidengine.MovementResult{
+		Description: "Check if the instance is available/exists",
+		Function:    utils.CallerPath(0),
+	}
+
+	instance, err := getRDSInstance(cfg)
+	if err != nil {
+		// Handle error
+		result.Message = err.Error()
+		result.Passed = false
+		return
+	}
+	result.Passed = len(instance.DBInstances) > 0
+	return
+}
+
+func getRDSInstance(cfg aws.Config) (instance *rds.DescribeDBInstancesOutput, err error) {
+	rdsClient := rds.NewFromConfig(cfg)
+	identifier, _ := getDBInstanceIdentifier()
+
+	input := &rds.DescribeDBInstancesInput{
+		DBInstanceIdentifier: aws.String(identifier),
+	}
+
+	instance, err = rdsClient.DescribeDBInstances(context.TODO(), input)
 	return
 }

--- a/strikes/common.go
+++ b/strikes/common.go
@@ -41,8 +41,8 @@ func getHostDBInstanceIdentifier() (string, error) {
 }
 
 func getHostRDSRegion() (string, error) {
-	if viper.IsSet("raids.RDS.aws.config.region") {
-		return viper.GetString("raids.RDS.aws.config.region"), nil
+	if viper.IsSet("raids.RDS.aws.config.primary_region") {
+		return viper.GetString("raids.RDS.aws.config.primary_region"), nil
 	}
 	return "", errors.New("database instance identifier must be set in the config file")
 }


### PR DESCRIPTION
This adds the strike for checking the specified rds has a multi region read replica created or not.
Did some code reconfiguration for common functions

Also added a map of aws regions to its abbreviations because of the output from the `DescribeDBInstanceAutomatedBackups` function

Checked against the privateer binary as well