### PR TITLE
fix: Remove failing lint step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,6 @@ jobs:
       run: |
             go mod download
             go get -t .
-    
-    - name: Lint
-      run: |
-        golint -set_exit_status ./...
 
     - name: Vet
       run: |


### PR DESCRIPTION
golint has been deprecated for a while, but it wasn't removed from the wireframe that this was built from. The fix is to just remove any references to golint.