### PR TITLE
Changed raids.RDS.aws to raids.rds

### DIFF
--- a/example-config.yml
+++ b/example-config.yml
@@ -1,12 +1,12 @@
 loglevel: Debug
 WriteDirectory: test_output
+AWS:
+  access_key: access
+  secret_key: supersecret
+  session_key: ""
+  region: us-east-1
 raids:
   rds:
-    creds:
-      aws_access_key: access
-      aws_secret_key: supersecret
-      aws_session_key: ""
-      aws_region: us-east-1
     config:
       instance_identifier: unique-id-name
       database: test

--- a/example-config.yml
+++ b/example-config.yml
@@ -1,22 +1,19 @@
 loglevel: Debug
 WriteDirectory: test_output
 raids:
-  RDS:
-    aws:
-      creds:
-        aws_access_key: access
-        aws_secret_key: supersecret
-        aws_session_key: ""
-        aws_region: us-east-1
-      config:
-        instance_identifier: unique-id-name
-        database: test
-        primary_region: us-east-1
-        host: localhost
-        password: password
-        port: 3306
-        user: root
-    # google
-    # azure
+  rds:
+    creds:
+      aws_access_key: access
+      aws_secret_key: supersecret
+      aws_session_key: ""
+      aws_region: us-east-1
+    config:
+      instance_identifier: unique-id-name
+      database: test
+      primary_region: us-east-1
+      host: localhost
+      password: password
+      port: 3306
+      user: root
     tactics:
       - CCC-Taxonomy

--- a/strikes/common.go
+++ b/strikes/common.go
@@ -48,15 +48,15 @@ func getHostRDSRegion() (string, error) {
 }
 
 func getAWSConfig() (cfg aws.Config, err error) {
-	if viper.IsSet("raids.rds.creds") &&
-		viper.IsSet("raids.rds.creds.aws_access_key") &&
-		viper.IsSet("raids.rds.creds.aws_secret_key") &&
-		viper.IsSet("raids.rds.creds.aws_region") {
+	if viper.IsSet("aws") &&
+		viper.IsSet("aws.access_key") &&
+		viper.IsSet("aws.secret_key") &&
+		viper.IsSet("aws.region") {
 
-		access_key := viper.GetString("raids.rds.creds.aws_access_key")
-		secret_key := viper.GetString("raids.rds.creds.aws_secret_key")
-		session_key := viper.GetString("raids.rds.creds.aws_session_key")
-		region := viper.GetString("raids.rds.creds.aws_region")
+		access_key := viper.GetString("aws.access_key")
+		secret_key := viper.GetString("aws.secret_key")
+		session_key := viper.GetString("aws.session_key")
+		region := viper.GetString("aws.region")
 
 		creds := credentials.NewStaticCredentialsProvider(access_key, secret_key, session_key)
 		cfg, err = config.LoadDefaultConfig(context.TODO(), config.WithCredentialsProvider(creds), config.WithRegion(region))

--- a/strikes/common.go
+++ b/strikes/common.go
@@ -27,36 +27,36 @@ func (a *Strikes) SetLogger(loggerName string) {
 }
 
 func getDBConfig() (string, error) {
-	if viper.IsSet("raids.RDS.aws.config.host") && viper.IsSet("raids.RDS.aws.config.database") {
+	if viper.IsSet("raids.rds.config.host") && viper.IsSet("raids.rds.config.database") {
 		return "database_host_placeholder", nil
 	}
 	return "", errors.New("database url must be set in the config file")
 }
 
 func getHostDBInstanceIdentifier() (string, error) {
-	if viper.IsSet("raids.RDS.aws.config.instance_identifier") {
-		return viper.GetString("raids.RDS.aws.config.instance_identifier"), nil
+	if viper.IsSet("raids.rds.config.instance_identifier") {
+		return viper.GetString("raids.rds.config.instance_identifier"), nil
 	}
 	return "", errors.New("database instance identifier must be set in the config file")
 }
 
 func getHostRDSRegion() (string, error) {
-	if viper.IsSet("raids.RDS.aws.config.primary_region") {
-		return viper.GetString("raids.RDS.aws.config.primary_region"), nil
+	if viper.IsSet("raids.rds.config.primary_region") {
+		return viper.GetString("raids.rds.config.primary_region"), nil
 	}
 	return "", errors.New("database instance identifier must be set in the config file")
 }
 
 func getAWSConfig() (cfg aws.Config, err error) {
-	if viper.IsSet("raids.RDS.aws.creds") &&
-		viper.IsSet("raids.RDS.aws.creds.aws_access_key") &&
-		viper.IsSet("raids.RDS.aws.creds.aws_secret_key") &&
-		viper.IsSet("raids.RDS.aws.creds.aws_region") {
+	if viper.IsSet("raids.rds.creds") &&
+		viper.IsSet("raids.rds.creds.aws_access_key") &&
+		viper.IsSet("raids.rds.creds.aws_secret_key") &&
+		viper.IsSet("raids.rds.creds.aws_region") {
 
-		access_key := viper.GetString("raids.RDS.aws.creds.aws_access_key")
-		secret_key := viper.GetString("raids.RDS.aws.creds.aws_secret_key")
-		session_key := viper.GetString("raids.RDS.aws.creds.aws_session_key")
-		region := viper.GetString("raids.RDS.aws.creds.aws_region")
+		access_key := viper.GetString("raids.rds.creds.aws_access_key")
+		secret_key := viper.GetString("raids.rds.creds.aws_secret_key")
+		session_key := viper.GetString("raids.rds.creds.aws_session_key")
+		region := viper.GetString("raids.rds.creds.aws_region")
 
 		creds := credentials.NewStaticCredentialsProvider(access_key, secret_key, session_key)
 		cfg, err = config.LoadDefaultConfig(context.TODO(), config.WithCredentialsProvider(creds), config.WithRegion(region))


### PR DESCRIPTION
Since the long-term vision is to limit the scope of each raid that we're asking folks to maintain, this raid should only encompass AWS. If Krumware wants to maintain additional raids for other RDMS services, that's absolutely awesome.

As such, we can limit the RDS config to simply `raids.rds.x`

Any pushback/critique/improvement is welcome in comments or via slack.