### PR TITLE
Added error handling for missing config vars

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,6 +22,11 @@ var (
 	Strikes  = &strikes.Strikes{}
 
 	AvailableStrikes = map[string][]raidengine.Strike{
+		"default": {
+			Strikes.SQLFeatures,
+			Strikes.AutomatedBackups,
+			Strikes.MultiRegion,
+		},
 		"CCC-Taxonomy": {
 			Strikes.SQLFeatures,
 			Strikes.AutomatedBackups,
@@ -39,7 +44,6 @@ var (
 			// Strikes.DNE,
 		},
 	}
-
 	// runCmd represents the base command when called without any subcommands
 	runCmd = &cobra.Command{
 		Use:   RaidName,


### PR DESCRIPTION
This follows the config var changes in #7 

## Changes

1. Added a "default" value for when raids don't specify a tactic
1. New function `checkConfigValues` checks for config vars and formats an error for any that are missing
1. Applied new func to all locations that check for a config value to be present

## Output

When run without any of the necessary variables:

```
raidname: RDS-CCC-Taxonomy
starttime: 2023-10-29 07:46:50.42559 -0500 CDT m=+0.003493667
endtime: 2023-10-29 07:46:50.425771 -0500 CDT m=+0.003675042
strikeresults:
    AutomatedBackups:
        passed: false
        description: Check for automated backups against the specified RDS instance
        message: 'Missing config values: raids.rds.creds.aws_access_key, raids.rds.creds.aws_secret_key, raids.rds.creds.aws_session_key, raids.rds.creds.aws_region'
        docsurl: https://www.github.com/krumIO/raid-rds
        controlid: CCC-Taxonomy-1
        movements: {}
    MultiRegion:
        passed: false
        description: Check if AWS RDS instance has multi region. This strike only checks for a read replica in a seperate region
        message: 'Missing config values: raids.rds.creds.aws_access_key, raids.rds.creds.aws_secret_key, raids.rds.creds.aws_session_key, raids.rds.creds.aws_region'
        docsurl: https://www.github.com/krumIO/raid-rds
        controlid: CCC-Taxonomy-1
        movements: {}
    SQLFeatures:
        passed: false
        description: This will perform various SQL queries
        message: 'Missing config values: raids.rds.config.host, raids.rds.config.database'
        docsurl: https://www.github.com/krumIO/raid-rds
        controlid: CCC-Taxonomy-1
        movements:
            ConnectToDB:
                passed: false
                description: The database host must be available and accepting connections
                message: 'Missing config values: raids.rds.config.host, raids.rds.config.database'
                function: github.com/krumIO/raid-rds/strikes.connectToDb
                value: null
```